### PR TITLE
Fix deprecated ruby 2.x feature

### DIFF
--- a/lib/arkency/feature_toggle.rb
+++ b/lib/arkency/feature_toggle.rb
@@ -10,7 +10,7 @@ module Arkency
       block.call if on?(name, *args)
     end
 
-    def on?(name, *args)
+    ruby2_keywords def on?(name, *args)
       @flags.fetch(name, proc{|*_args| false }).call(*args)
     end
 


### PR DESCRIPTION
Fix the warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

Reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/